### PR TITLE
Created browser version of batch upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .DS_Store
 .env
 node_modules
-resources/*.zip
-resources/*.JPG
-resources/*.jpg
+resources/*.*
+!resources/add-files-here.txt
+
+# Local notes
+__*.*
+__*
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+</head>
+<body>
+  <i>Credentials:</i><br />
+  <label for="username">username:&nbsp;</label><input type="text" id="username">
+  <label for="password">password:&nbsp;</label><input type="password" id="password">
+  <label for="portal">portal:&nbsp;</label><input type="text" id="portal" style="width:256px" placeholder="https://www.arcgis.com">
+  <br /><br />
+  buffer size: <input type="text" id="bufferSize" placeholder="10" maxlength="2" size="2" />
+  <br><br>
+  <input type="file" id="files" name="files[]" multiple />
+  <br><br>
+  <output id="list"></output>
+
+  <script src="https://requirejs.org/docs/release/2.3.6/minified/require.js"></script>
+  <script>
+    require.config({
+      paths: {
+        "@esri/arcgis-rest-auth": "node_modules/@esri/arcgis-rest-auth/dist/umd/auth.umd.min",
+        "@esri/arcgis-rest-portal": "node_modules/@esri/arcgis-rest-portal/dist/umd/portal.umd.min",
+        "@esri/arcgis-rest-request": "node_modules/@esri/arcgis-rest-request/dist/umd/request.umd.min",
+        "@esri/hub-common": "node_modules/@esri/hub-common/dist/umd/common.umd.min"
+      }
+    });
+
+    require(["@esri/arcgis-rest-auth", "@esri/arcgis-rest-portal", "@esri/hub-common"],
+      function (auth, portal, hubCommon) {
+
+        function handleFileSelect(evt) {
+          var session = new auth.UserSession({
+            username: document.getElementById("username").value,
+            password: document.getElementById("password").value,
+            portal: (document.getElementById("portal").value || "https://www.arcgis.com") + "/sharing/rest"
+          });
+          var bufferSize = document.getElementById('bufferSize').value || 10;
+          var files = evt.target.files; // FileList object
+
+          let createdItemId = ''
+          return createHostItem(session, bufferSize)
+          .then((id) => {
+            createdItemId = id;
+            return uploadFiles(files, createdItemId, session);
+          })
+          .then(() => {
+            return portal.getItemResources(createdItemId, {authentication: session});
+          })
+          .then((response) => {
+            // now compare this to the filenames
+            document.getElementById('list').innerHTML =
+              `Created item ${createdItemId}<br>` +
+              `AGO Reports the item has ${response.resources.length} resources, and we uploaded ${files.length} resources`;
+          });
+        }
+
+        function createHostItem(session, bufferSize) {
+          return portal.createItem({
+            item: {
+              type: 'Web Mapping Application',
+              title: `Resource Upload Test - x${bufferSize}`,
+              tags: ['test'],
+              typeKeywords: ['resourceTest']
+            },
+            authentication: session
+          })
+          .then((resp) => {
+            console.log(`Created Host Item ${resp.id}`);
+            return resp.id;
+          })
+          .catch((ex) => {
+            console.error(`Error creating hostItem`, ex);
+          })
+        }
+
+        function uploadFiles (files, itemId, authentication) {
+          const fileOpts = Array.from(files).map((file) => {
+            return {
+              itemId,
+              filename: file.name,
+              filedata: file
+            }
+          });
+          // partially apply auth and a catch
+          const uploadWithAuth = (opts) => {
+            return uploadResource(opts, authentication)
+            .catch(e => {
+              console.error(`Error uploading resource ${opts.filename} :: ${e.message}`);
+              return {success: false};
+            });
+          };
+          return hubCommon.batch(fileOpts, uploadWithAuth, bufferSize)
+          .then((resps) => {
+            console.log(`Uploads complete.`);
+            resps.forEach((r) => {
+              console.log(`   API Response from /addResource: ${r.success}`);
+            });
+          })
+          .catch((err) => {
+            console.error(`Caught error: ${err.message}`);
+          })
+        }
+
+        function uploadResource(imgOpts, authentication) {
+          console.log(`uploadResource ${imgOpts.filename} to ${imgOpts.itemId}`);
+          return portal.addItemResource({
+            authentication,
+            resource: imgOpts.filedata,
+            name: imgOpts.filename,
+            id: imgOpts.itemId,
+            params: {
+              method: 'POST'
+            }
+          })
+          .then((resp) => {
+            console.log(`Added ${imgOpts.filename} to item ${imgOpts.itemId}`);
+            return resp;
+          })
+          .catch(ex => {
+            console.log(`Error adding ${imgOpts.filename} to item ${imgOpts.itemId} ::${ex.message} `);
+            return {success: false};
+          })
+        }
+
+        document.getElementById('files').addEventListener('change', handleFileSelect, false);
+      }
+    );
+  </script>
+</body>
+</html>


### PR DESCRIPTION
With the browser version, I hope to more closely copy the multiple-upload problem. This app loads all of the files, and then sends them up to AGO using specified batch file sizes. As with the index.js version, it checks the number of resources found in the created item against the number uploaded.

Also lightly tweaked .gitignore to exclude all files except the "add-files-here.txt" placeholder file.